### PR TITLE
on edit page, put inscription text field next to photo of inscription

### DIFF
--- a/www/edit.php
+++ b/www/edit.php
@@ -141,7 +141,12 @@ if($twitter[1] != null){
 			<input type="hidden" id="newLongitude" name="newLongitude" value="<?php echo $benchLong; ?>"/>
 			<input type="hidden" id="newLatitude"  name="newLatitude"  value="<?php echo $benchLat;  ?>"/>
 			<input type="submit" value="Save Changes" />
-		</div>
+		</div>&nbsp;
+
+		<div>
+			<label for="inscription">Change Inscription?</label><br>
+			<textarea id="inscription" name="inscription" cols="40" rows="6"><?php echo $benchInscription; ?></textarea>
+		</div>&nbsp;
 
 		<div id='benchImage'>
 			<?php echo get_image_html($benchID); ?>
@@ -193,11 +198,6 @@ if($twitter[1] != null){
 			</fieldset>
 		</div>
 		<br>
-
-		<div>
-			<label for="inscription">Change Inscription?</label><br>
-			<textarea id="inscription" name="inscription" cols="40" rows="6"><?php echo $benchInscription; ?></textarea>
-		</div>
 
 		<br>
 		<input type="radio" id="publishedTrue"  name="published" value="true" checked>


### PR DESCRIPTION
Textarea is above the photo of the inscription rather than underneath as I suggested because the html for all the existing photos is put in the page by
`                        <?php echo get_image_html($benchID); ?>`
and I didn't want to get in to messing with that function. 
I've put in a `&nbsp;` before and after the div to put a bit of space between textarea and the elements above and below as it looked weird all squished up. Using `&nbsp;` feels wrong but I copied from elsewhere in the PHP.