### PR TITLE
for issue 165 - api returns truncated inscriptions

### DIFF
--- a/www/bench.php
+++ b/www/bench.php
@@ -58,7 +58,7 @@ if ($benchAddress == null){
 		<a href="/add" class="hand-drawn">Add new bench</a>
 		<a href="/edit/<?php echo $benchID; ?>" class="hand-drawn">Edit this bench</a>
 	</div>
-<script src="/data.json/?bench=<?php echo $benchID; ?>" type="text/javascript"></script>
+<script src="/data.json/?forMap=true&bench=<?php echo $benchID; ?>" type="text/javascript"></script>
 
 <?php echo get_map_javascript($benchLat, $benchLong, "16"); ?>
 

--- a/www/data.json.php
+++ b/www/data.json.php
@@ -7,13 +7,21 @@ $format    = $_GET["format"];
 $latitude  = $_GET["latitude"];
 $longitude = $_GET["longitude"];
 $radius    = $_GET["radius"];
+$forMap    = $_GET["forMap"];
+
+if ( "true" == $forMap) {
+  $forMap = True;
+} else {
+  $forMap = False;
+}
 
 if (null != $latitude && null != $longitude && null != $radius) {
-	$geojson = get_nearest_benches($latitude, $longitude, $radius);
+	$geojson = get_nearest_benches($latitude, $longitude, $radius, 20, $forMap);
 } else if (null != $benchID){
-	$geojson = get_bench($benchID);
+	$geojson = get_bench($benchID,$forMap);
 } else {
-	$geojson = get_all_benches();
+	$geojson = get_all_benches(0, true, $forMap);
+	
 }
 
 

--- a/www/edit.php
+++ b/www/edit.php
@@ -214,7 +214,7 @@ if($twitter[1] != null){
 
 	</form>
 
-<script src="/data.json/?bench=<?php echo $benchID; ?>" type="text/javascript"></script>
+<script src="/data.json/?forMap=true&bench=<?php echo $benchID; ?>" type="text/javascript"></script>
 
 <?php echo get_map_javascript($benchLat, $benchLong, "16"); ?>
 

--- a/www/front.php
+++ b/www/front.php
@@ -32,7 +32,7 @@
 			<a href="/add/" class="hand-drawn">Add bench</a>
 		</form>
 	</div>
-<script src="/data.json/" type="text/javascript"></script>
+<script src="/data.json/?forMap=true" type="text/javascript"></script>
 
 <?php echo get_map_javascript(); ?>
 


### PR DESCRIPTION


Here's my attempt at fix for #165 and the bit of a fix I wrote for #166 before you closed that issue literally minutes after I'd typed the relevant line of code. :D

Lack of PHP support for named parameters means I made the call to `get_all_benches()` in `data.json` pass a value for all three parameters and since that call didn't previously specify any values, it now specifies the defaults for `$id` and `$only_published`. Same for `get_nearest_benches()` and `$limit`. I didn't want to get in to changing parameter order.

I've expanded upon rather than attempted to do anything about there being identical code in `get_all_benches()` and `get_nearest_bench()` which seems less than ideal.

`data.json` now takes an extra parameter `forMap` which when set to `true` causes it to return inscriptions which are truncated, where required, and contain `<br>` elements, where required.

Examples of output with this stuff in place:

Where inscription is all on one line and short enough truncation for map
```
$ curl -k 'https://localhost/data.json/?bench=108';echo
var benches = {"type":"FeatureCollection","features":[{"id":108,"type":"Feature","geometry":{"type":"Point","coordinates":[-2.340448,51.39846]},"properties":{"popupContent":"For Barry and Mary Rose Hogan who loved Bath"}}]}
$ curl -k 'https://localhost/data.json/?bench=108&forMap=true';echo
var benches = {"type":"FeatureCollection","features":[{"id":108,"type":"Feature","geometry":{"type":"Point","coordinates":[-2.340448,51.39846]},"properties":{"popupContent":"For Barry and Mary Rose Hogan who loved Bath"}}]}
$
```

Where inscription long enough to require inscription be truncated for map:
```
$ curl -k 'https://localhost/data.json/?bench=150';echo
var benches = {"type":"FeatureCollection","features":[{"id":150,"type":"Feature","geometry":{"type":"Point","coordinates":[-2.339523,51.39785]},"properties":{"popupContent":"BUFFY ANNE SUMMERS\r\n1981 - 2001\r\nBELOVED SISTER\r\nDEVOTED FRIEND\r\nSHE SAVED THE WORLD\r\nA LOT\r\nsome more text to test\r\ntruncation and stuff\r\nblah blah blah\r\nfoo foo foo\r\nmoo moo moo\r\nbar bar bar\r\nqux qux qux\r\nmonkey monkey monkey\r\ndog dog dog\r\ncat cat cat"}}]}
$ curl -k 'https://localhost/data.json/?bench=150&forMap=true';echo
var benches = {"type":"FeatureCollection","features":[{"id":150,"type":"Feature","geometry":{"type":"Point","coordinates":[-2.339523,51.39785]},"properties":{"popupContent":"BUFFY ANNE SUMMERS<br \/>\r\n1981 - 2001<br \/>\r\nBELOVED SISTER<br \/>\r\nDEVOTED FRIEND<br \/>\r\nSHE SAVED THE WORLD<br \/>\r\nA LOT<br \/>\r\nsome more text to test<br \/>\r\ntruncation \u2026"}}]}
$ curl -k 'https://localhost/data.json/?bench=150&forMap=nonsense';echo
var benches = {"type":"FeatureCollection","features":[{"id":150,"type":"Feature","geometry":{"type":"Point","coordinates":[-2.339523,51.39785]},"properties":{"popupContent":"BUFFY ANNE SUMMERS\r\n1981 - 2001\r\nBELOVED SISTER\r\nDEVOTED FRIEND\r\nSHE SAVED THE WORLD\r\nA LOT\r\nsome more text to test\r\ntruncation and stuff\r\nblah blah blah\r\nfoo foo foo\r\nmoo moo moo\r\nbar bar bar\r\nqux qux qux\r\nmonkey monkey monkey\r\ndog dog dog\r\ncat cat cat"}}]}
$
```

Where inscription contains some characters I got by putting a long inscription to to Google Translate and requesting Chinese:
```
$ curl -k 'https://localhost/data.json/?bench=110';echo
var benches = {"type":"FeatureCollection","features":[{"id":110,"type":"Feature","geometry":{"type":"Point","coordinates":[-2.340125,51.398582]},"properties":{"popupContent":"\u8fd9\u4e2a\u66ff\u8865\u5e2d\u662f\u4e3aDavid Llewllyn Thomas\u6350\u8d60\u7684\u3002\u4e00\u4f4d\u51fa\u751f\u4e8e\u7687\u5bb6Cresent\u7684\u8001\u7231\u5fb7\u534e\u65f6\u4ee3\u4eba\u3002\u4ed6\u7279\u522b\u559c\u6b22\u5728\u590f\u5929\u5750\u5728\u8fd9\u4e2a\u516c\u56ed\u91cc\u542c\u4e50\u961f\u6f14\u594f \u8fd9\u4e2a\u66ff\u8865\u5e2d\u662f\u4e3aDavid Llewllyn Thomas\u6350\u8d60\u7684\u3002\u4e00\u4f4d\u51fa\u751f\u4e8e\u7687\u5bb6Cresent\u7684\u8001\u7231\u5fb7\u534e\u65f6\u4ee3\u4eba\u3002\u4ed6\u7279\u522b\u559c\u6b22\u5728\u590f\u5929\u5750\u5728\u8fd9\u4e2a\u516c\u56ed\u91cc\u542c\u4e50\u961f\u6f14\u594f"}}]}
$ curl -k 'https://localhost/data.json/?bench=110&forMap=true';echo
var benches = {"type":"FeatureCollection","features":[{"id":110,"type":"Feature","geometry":{"type":"Point","coordinates":[-2.340125,51.398582]},"properties":{"popupContent":"\u8fd9\u4e2a\u66ff\u8865\u5e2d\u662f\u4e3aDavid Llewllyn Thomas\u6350\u8d60\u7684\u3002\u4e00\u4f4d\u51fa\u751f\u4e8e\u7687\u5bb6Cresent\u7684\u8001\u7231\u5fb7\u534e\u65f6\u4ee3\u4eba\u3002\u4ed6\u7279\u522b\u559c\u6b22\u5728\u590f\u5929\u5750\u5728\u8fd9\u4e2a\u516c\u56ed\u91cc\u542c\u4e50\u961f\u6f14\u594f \u8fd9\u4e2a\u66ff\u8865\u5e2d\u662f\u4e3aDavid Llewllyn Thomas\u6350\u8d60\u7684\u3002\u4e00\u4f4d\u51fa\u751f\u4e8e\u7687\u5bb6Cresent\u7684\u8001\u7231\u5fb7\u534e\u65f6\u2026"}}]}
$
```

With lat, long, radius
```
$ curl -k 'https://localhost/data.json/?format=raw&latitude=51.39785&longitude=-2.339523&radius=0.01';echo
{"type":"FeatureCollection","features":[{"id":150,"type":"Feature","geometry":{"type":"Point","coordinates":[-2.339523,51.39785]},"properties":{"popupContent":"BUFFY ANNE SUMMERS\r\n1981 - 2001\r\nBELOVED SISTER\r\nDEVOTED FRIEND\r\nSHE SAVED THE WORLD\r\nA LOT\r\nsome more text to test\r\ntruncation and stuff\r\nblah blah blah\r\nfoo foo foo\r\nmoo moo moo\r\nbar bar bar\r\nqux qux qux\r\nmonkey monkey monkey\r\ndog dog dog\r\ncat cat cat"}}]}
$ curl -k 'https://localhost/data.json/?format=raw&latitude=51.39785&longitude=-2.339523&radius=0.01&forMap=true';echo
{"type":"FeatureCollection","features":[{"id":150,"type":"Feature","geometry":{"type":"Point","coordinates":[-2.339523,51.39785]},"properties":{"popupContent":"BUFFY ANNE SUMMERS<br \/>\r\n1981 - 2001<br \/>\r\nBELOVED SISTER<br \/>\r\nDEVOTED FRIEND<br \/>\r\nSHE SAVED THE WORLD<br \/>\r\nA LOT<br \/>\r\nsome more text to test<br \/>\r\ntruncation \u2026"}}]}
$
```



